### PR TITLE
feat:フォロー機能の追加[WIP] #11

### DIFF
--- a/backend/app/Http/Controllers/UserController.php
+++ b/backend/app/Http/Controllers/UserController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\User;
+use Illuminate\Http\Request;
+
+class UserController extends Controller
+{
+    public function show(string $name)
+    {
+        $user = User::where('name',$name)->first();
+
+        return view('users.show',[
+            'user' => $user,
+        ]);
+    }
+}

--- a/backend/app/User.php
+++ b/backend/app/User.php
@@ -5,6 +5,7 @@ namespace App;
 use App\Mail\BareMail;
 use App\Notifications\PasswordResetNotification;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -42,5 +43,15 @@ class User extends Authenticatable
     public function sendPasswordResetNotification($token)
     {
         $this->notify(new PasswordResetNotification($token,new BareMail()));
+    }
+    public function followers(): BelongsToMany
+    {
+        return $this->belongsToMany('App\User','follows','followee_id','follower_id')->withTimestamps();
+    }
+    public function isFollowedBy(?User $user): bool
+    {
+        return $user
+            ? (bool)$this->followers->where('id',$user->id)->count()
+            : false;
     }
 }

--- a/backend/database/migrations/2021_01_16_081854_create_follows_table.php
+++ b/backend/database/migrations/2021_01_16_081854_create_follows_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateFollowsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('follows', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('follower_id')->unsigned();
+            $table->foreign('follower_id')
+              ->references('id')
+              ->on('users')
+              ->onDelete('cascade');
+            $table->bigInteger('followee_id')->unsigned();
+            $table->foreign('followee_id')
+              ->references('id')
+              ->on('users')
+              ->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('follows');
+    }
+}

--- a/backend/public/js/app.js
+++ b/backend/public/js/app.js
@@ -1956,6 +1956,57 @@ __webpack_require__.r(__webpack_exports__);
 
 /***/ }),
 
+/***/ "./node_modules/babel-loader/lib/index.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/FollowButton.vue?vue&type=script&lang=js&":
+/*!***********************************************************************************************************************************************************************!*\
+  !*** ./node_modules/babel-loader/lib??ref--4-0!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/components/FollowButton.vue?vue&type=script&lang=js& ***!
+  \***********************************************************************************************************************************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+/* harmony default export */ __webpack_exports__["default"] = ({
+  props: {
+    initialIsFollowedBy: {
+      type: Boolean,
+      "default": false
+    }
+  },
+  data: function data() {
+    return {
+      isFollowedBy: this.initialIsFollowedBy
+    };
+  },
+  computed: {
+    buttonColor: function buttonColor() {
+      return this.isFollowedBy ? 'bg-primary text-white' : 'bg-white';
+    },
+    buttonIcon: function buttonIcon() {
+      return this.isFollowedBy ? 'fas fa-user-check' : 'fas fa-user-plus';
+    },
+    buttonText: function buttonText() {
+      return this.isFollowedBy ? 'フォロー中' : 'フォロー';
+    }
+  }
+});
+
+/***/ }),
+
 /***/ "./node_modules/babel-loader/lib/index.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/ProjectLike.vue?vue&type=script&lang=js&":
 /*!**********************************************************************************************************************************************************************!*\
   !*** ./node_modules/babel-loader/lib??ref--4-0!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/components/ProjectLike.vue?vue&type=script&lang=js& ***!
@@ -39478,6 +39529,42 @@ render._withStripped = true
 
 /***/ }),
 
+/***/ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/FollowButton.vue?vue&type=template&id=426ba0ae&":
+/*!***************************************************************************************************************************************************************************************************************!*\
+  !*** ./node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/components/FollowButton.vue?vue&type=template&id=426ba0ae& ***!
+  \***************************************************************************************************************************************************************************************************************/
+/*! exports provided: render, staticRenderFns */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "render", function() { return render; });
+/* harmony export (binding) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return staticRenderFns; });
+var render = function() {
+  var _vm = this
+  var _h = _vm.$createElement
+  var _c = _vm._self._c || _h
+  return _c("div", [
+    _c(
+      "button",
+      {
+        staticClass: "btn-sm shadow-none border border-primary p-2",
+        class: _vm.buttonColor
+      },
+      [
+        _c("i", { staticClass: "mr-1", class: _vm.buttonIcon }),
+        _vm._v("\n    " + _vm._s(_vm.buttonText) + "\n    ")
+      ]
+    )
+  ])
+}
+var staticRenderFns = []
+render._withStripped = true
+
+
+
+/***/ }),
+
 /***/ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/ProjectLike.vue?vue&type=template&id=14f48d35&":
 /*!**************************************************************************************************************************************************************************************************************!*\
   !*** ./node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!./node_modules/vue-loader/lib??vue-loader-options!./resources/js/components/ProjectLike.vue?vue&type=template&id=14f48d35& ***!
@@ -51747,6 +51834,7 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var vue__WEBPACK_IMPORTED_MODULE_3___default = /*#__PURE__*/__webpack_require__.n(vue__WEBPACK_IMPORTED_MODULE_3__);
 /* harmony import */ var _components_ProjectLike__WEBPACK_IMPORTED_MODULE_4__ = __webpack_require__(/*! ./components/ProjectLike */ "./resources/js/components/ProjectLike.vue");
 /* harmony import */ var _components_ProjectTagsInput__WEBPACK_IMPORTED_MODULE_5__ = __webpack_require__(/*! ./components/ProjectTagsInput */ "./resources/js/components/ProjectTagsInput.vue");
+/* harmony import */ var _components_FollowButton__WEBPACK_IMPORTED_MODULE_6__ = __webpack_require__(/*! ./components/FollowButton */ "./resources/js/components/FollowButton.vue");
 /**
  * First we will load all of this project's JavaScript dependencies which
  * includes Vue and other libraries. It is a great starting point when
@@ -51777,11 +51865,13 @@ vue__WEBPACK_IMPORTED_MODULE_3___default.a.use(semantic_ui_vue__WEBPACK_IMPORTED
 
 
 
+
 var app = new vue__WEBPACK_IMPORTED_MODULE_3___default.a({
   el: '#app',
   components: {
     ProjectLike: _components_ProjectLike__WEBPACK_IMPORTED_MODULE_4__["default"],
-    ProjectTagsInput: _components_ProjectTagsInput__WEBPACK_IMPORTED_MODULE_5__["default"]
+    ProjectTagsInput: _components_ProjectTagsInput__WEBPACK_IMPORTED_MODULE_5__["default"],
+    FollowButton: _components_FollowButton__WEBPACK_IMPORTED_MODULE_6__["default"]
   }
 });
 
@@ -51897,6 +51987,75 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_ExampleComponent_vue_vue_type_template_id_299e239e___WEBPACK_IMPORTED_MODULE_0__["render"]; });
 
 /* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_ExampleComponent_vue_vue_type_template_id_299e239e___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
+
+
+
+/***/ }),
+
+/***/ "./resources/js/components/FollowButton.vue":
+/*!**************************************************!*\
+  !*** ./resources/js/components/FollowButton.vue ***!
+  \**************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _FollowButton_vue_vue_type_template_id_426ba0ae___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! ./FollowButton.vue?vue&type=template&id=426ba0ae& */ "./resources/js/components/FollowButton.vue?vue&type=template&id=426ba0ae&");
+/* harmony import */ var _FollowButton_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./FollowButton.vue?vue&type=script&lang=js& */ "./resources/js/components/FollowButton.vue?vue&type=script&lang=js&");
+/* empty/unused harmony star reexport *//* harmony import */ var _node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_2__ = __webpack_require__(/*! ../../../node_modules/vue-loader/lib/runtime/componentNormalizer.js */ "./node_modules/vue-loader/lib/runtime/componentNormalizer.js");
+
+
+
+
+
+/* normalize component */
+
+var component = Object(_node_modules_vue_loader_lib_runtime_componentNormalizer_js__WEBPACK_IMPORTED_MODULE_2__["default"])(
+  _FollowButton_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_1__["default"],
+  _FollowButton_vue_vue_type_template_id_426ba0ae___WEBPACK_IMPORTED_MODULE_0__["render"],
+  _FollowButton_vue_vue_type_template_id_426ba0ae___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"],
+  false,
+  null,
+  null,
+  null
+  
+)
+
+/* hot reload */
+if (false) { var api; }
+component.options.__file = "resources/js/components/FollowButton.vue"
+/* harmony default export */ __webpack_exports__["default"] = (component.exports);
+
+/***/ }),
+
+/***/ "./resources/js/components/FollowButton.vue?vue&type=script&lang=js&":
+/*!***************************************************************************!*\
+  !*** ./resources/js/components/FollowButton.vue?vue&type=script&lang=js& ***!
+  \***************************************************************************/
+/*! exports provided: default */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _node_modules_babel_loader_lib_index_js_ref_4_0_node_modules_vue_loader_lib_index_js_vue_loader_options_FollowButton_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! -!../../../node_modules/babel-loader/lib??ref--4-0!../../../node_modules/vue-loader/lib??vue-loader-options!./FollowButton.vue?vue&type=script&lang=js& */ "./node_modules/babel-loader/lib/index.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/FollowButton.vue?vue&type=script&lang=js&");
+/* empty/unused harmony star reexport */ /* harmony default export */ __webpack_exports__["default"] = (_node_modules_babel_loader_lib_index_js_ref_4_0_node_modules_vue_loader_lib_index_js_vue_loader_options_FollowButton_vue_vue_type_script_lang_js___WEBPACK_IMPORTED_MODULE_0__["default"]); 
+
+/***/ }),
+
+/***/ "./resources/js/components/FollowButton.vue?vue&type=template&id=426ba0ae&":
+/*!*********************************************************************************!*\
+  !*** ./resources/js/components/FollowButton.vue?vue&type=template&id=426ba0ae& ***!
+  \*********************************************************************************/
+/*! exports provided: render, staticRenderFns */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+__webpack_require__.r(__webpack_exports__);
+/* harmony import */ var _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_FollowButton_vue_vue_type_template_id_426ba0ae___WEBPACK_IMPORTED_MODULE_0__ = __webpack_require__(/*! -!../../../node_modules/vue-loader/lib/loaders/templateLoader.js??vue-loader-options!../../../node_modules/vue-loader/lib??vue-loader-options!./FollowButton.vue?vue&type=template&id=426ba0ae& */ "./node_modules/vue-loader/lib/loaders/templateLoader.js?!./node_modules/vue-loader/lib/index.js?!./resources/js/components/FollowButton.vue?vue&type=template&id=426ba0ae&");
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "render", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_FollowButton_vue_vue_type_template_id_426ba0ae___WEBPACK_IMPORTED_MODULE_0__["render"]; });
+
+/* harmony reexport (safe) */ __webpack_require__.d(__webpack_exports__, "staticRenderFns", function() { return _node_modules_vue_loader_lib_loaders_templateLoader_js_vue_loader_options_node_modules_vue_loader_lib_index_js_vue_loader_options_FollowButton_vue_vue_type_template_id_426ba0ae___WEBPACK_IMPORTED_MODULE_0__["staticRenderFns"]; });
 
 
 

--- a/backend/public/mix-manifest.json
+++ b/backend/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/app.js": "/js/app.js?id=c775ad3f4f9c5d0bf0ad",
+    "/js/app.js": "/js/app.js?id=e72b87f4ec6b6b5ffc16",
     "/css/app.css": "/css/app.css?id=f4d8b4dcea3280933ba3"
 }

--- a/backend/resources/js/app.js
+++ b/backend/resources/js/app.js
@@ -32,12 +32,14 @@ Vue.use(SuiVue);
 import Vue from 'vue'
 import ProjectLike from './components/ProjectLike'
 import ProjectTagsInput from './components/ProjectTagsInput'
+import FollowButton from './components/FollowButton'
 
 const app = new Vue({
     el: '#app',
     components: {
         ProjectLike,
         ProjectTagsInput,
+        FollowButton,
     }
 });
 

--- a/backend/resources/js/components/FollowButton.vue
+++ b/backend/resources/js/components/FollowButton.vue
@@ -1,0 +1,47 @@
+<template>
+    <div>
+        <button
+         class="btn-sm shadow-none border border-primary p-2"
+         :class="buttonColor"
+        >
+        <i
+         class="mr-1"
+         :class="buttonIcon"
+        ></i>
+        {{ buttonText }}
+        </button>
+    </div>
+</template>
+
+<script>
+export default {
+    props: {
+        initialIsFollowedBy: {
+            type:Boolean,
+            default:false,
+        },
+    },
+    data() {
+        return {
+            isFollowedBy: this.initialIsFollowedBy,
+        }
+    },
+    computed: {
+        buttonColor() {
+            return this.isFollowedBy
+              ? 'bg-primary text-white'
+              : 'bg-white'
+        },
+        buttonIcon() {
+            return this.isFollowedBy
+              ? 'fas fa-user-check'
+              : 'fas fa-user-plus'
+        },
+        buttonText() {
+            return this.isFollowedBy
+              ? 'フォロー中'
+              : 'フォロー'
+        },
+    },
+}
+</script>

--- a/backend/resources/views/nav.blade.php
+++ b/backend/resources/views/nav.blade.php
@@ -12,7 +12,7 @@
         <div class="ui simple dropdown small item">
             マイメニュー <i class="dropdown icon"></i>
             <div class="menu">
-                <a class="item" href="#">マイページ</a>
+                <a class="item" href="{{ route('users.show',['name'=>Auth::user()->name]) }}">マイページ</a>
                 <a class="item" href="#">設定</a>
                 <div class="divider"></div>
                 <div class="header">ログアウト</div>

--- a/backend/resources/views/projects/card.blade.php
+++ b/backend/resources/views/projects/card.blade.php
@@ -1,72 +1,74 @@
+<div class="ui link Centered card">
+    <div class="content">
+        <!--<i class="right floated like icon"></i>-->
+        <span class="right floated">10</span>
+        <i class="right floated comment outline icon"></i>
 
-    <div class="ui link Centered card">
-        <div class="content">
-            <!--<i class="right floated like icon"></i>-->
-            <span class="right floated">10</span>
-            <i class="right floated comment outline icon"></i>
-
-            <project-like :initial-is-liked-by='@json($project->isLikedBy(Auth::user()))'
-                          :initial-count-likes='@json($project->count_likes)'
-                          :authorized='@json(Auth::check())'
-                          endpoint="{{ route('projects.like',['project' => $project]) }}">
-            </project-like>
-            <div class="header">
-                <a href="{{ route('projects.show',['project' => $project]) }}">{{ $project->project_name }}</a>
+        <project-like :initial-is-liked-by='@json($project->isLikedBy(Auth::user()))'
+            :initial-count-likes='@json($project->count_likes)' :authorized='@json(Auth::check())'
+            endpoint="{{ route('projects.like',['project' => $project]) }}">
+        </project-like>
+        <div class="header">
+            <a href="{{ route('projects.show',['project' => $project]) }}">{{ $project->project_name }}</a>
+        </div>
+        @if( Auth::id()===$project->user_id )
+        <div class="ui simple dropdown small item right floated">
+            <i class="dropdown icon"></i>
+            <div class="menu">
+                <a href="{{ route('projects.edit',['project'=>$project]) }}" class="item">編集</a>
+                <a data-toggle="modal" data-target="#modal-delete-{{ $project->id }}" class="item">削除</a>
             </div>
-            @if( Auth::id()===$project->user_id )
-            <div class="ui simple dropdown small item right floated">
-                <i class="dropdown icon"></i>
-                <div class="menu">
-                    <a href="{{ route('projects.edit',['project'=>$project]) }}" class="item">編集</a>
-                    <a data-toggle="modal" data-target="#modal-delete-{{ $project->id }}" class="item">削除</a>
-                </div>
-            </div>
-            <!-- modal -->
-            <div id="modal-delete-{{ $project->id }}" class="modal fade" tabindex="-1" role="dialog">
-                <div class="modal-dialog" role="document">
-                    <div class="modal-content">
-                        <div class="modal-header">
-                            <button type="button" class="close" data-dismiss="modal" aria-label="閉じる">
-                                <span aria-hidden="true">&times;</span>
-                            </button>
-                        </div>
-                        <form method="POST" action="{{ route('projects.destroy', ['project' => $project]) }}">
-                            @csrf
-                            @method('DELETE')
-                            <div class="modal-body">
-                                {{ $project->title }}を削除します。よろしいですか？
-                            </div>
-                            <div class="modal-footer justify-content-between">
-                                <a class="btn btn-outline-grey" data-dismiss="modal">キャンセル</a>
-                                <button type="submit" class="btn btn-danger">削除する</button>
-                            </div>
-                        </form>
+        </div>
+        <!-- modal -->
+        <div id="modal-delete-{{ $project->id }}" class="modal fade" tabindex="-1" role="dialog">
+            <div class="modal-dialog" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-label="閉じる">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
                     </div>
-                </div>
-            </div>
-            <!-- modal -->
-            @endif
-            <div class="meta">
-                <span class="category">
-                    {{ $project->project_description }}
-                </span>
-            </div>
-            <div class="ui yellow　active progress" data-percent="70">
-                <div class="bar">
-                    <div class="progress"></div>
+                    <form method="POST" action="{{ route('projects.destroy', ['project' => $project]) }}">
+                        @csrf
+                        @method('DELETE')
+                        <div class="modal-body">
+                            {{ $project->title }}を削除します。よろしいですか？
+                        </div>
+                        <div class="modal-footer justify-content-between">
+                            <a class="btn btn-outline-grey" data-dismiss="modal">キャンセル</a>
+                            <button type="submit" class="btn btn-danger">削除する</button>
+                        </div>
+                    </form>
                 </div>
             </div>
         </div>
-        @foreach($project->tags as $tag)
-          @if($loop ->first)
-            <div class="extra content">
-          @endif
-            <a href="{{ route('tags.show',['name'=>$tag->name]) }}" class="ui basic label">{{ $tag->hashtag }}</a>
-          @endforeach
-            <div class="right floated author">
-                <img class="ui avatar image" src="/images/avatar/small/matt.jpg">
-                {{ $project->user->name}}
+        <!-- modal -->
+        @endif
+        <div class="meta">
+            <span class="category">
+                {{ $project->project_description }}
+            </span>
+        </div>
+        <div class="ui yellow　active progress" data-percent="70">
+            <div class="bar">
+                <div class="progress"></div>
             </div>
-            <p class="small right floated">登録日 : {{ $project->created_at->format('Y/m/d H:i') }}</p>
         </div>
     </div>
+    @foreach($project->tags as $tag)
+    @if($loop ->first)
+    <div class="extra content">
+        @endif
+        <a href="{{ route('tags.show',['name'=>$tag->name]) }}" class="ui basic label">{{ $tag->hashtag }}</a>
+        @endforeach
+        <div class="right floated author">
+            <a href="{{ route('users.show',['name' => $project->user->name]) }}">
+                <img class="ui avatar image" src="/images/avatar/small/matt.jpg">
+            </a>
+            <a href="{{ route('users.show',['name'=> $project->user->name]) }}">
+                {{ $project->user->name}}
+            </a>
+        </div>
+        <p class="small right floated">登録日 : {{ $project->created_at->format('Y/m/d H:i') }}</p>
+    </div>
+</div>

--- a/backend/resources/views/users/show.blade.php
+++ b/backend/resources/views/users/show.blade.php
@@ -1,0 +1,41 @@
+@extends('layouts.app')
+
+@section('title',$user->name)
+
+@section('content')
+{{-- @include('nav') --}}
+
+<div class="container">
+    <div class="card mt-3">
+        <div class="card-body">
+            <div class="d-flex flex-row">
+                <a href="{{ route('users.show',['name'=>$user->name]) }}" class="text-dark">
+                    <i class="fas da-user-circle fa-3x"></i>
+                </a>
+                @if( Auth::id()!== $user->id )
+                <follow-button
+                 class="ml-auto"
+                 :initial-is-followed-by='@json($user->isFollowedBy(Auth::user()))'
+                >
+                </follow-button>
+                @endif
+            </div>
+            <h2 class="h5 card-title m-o">
+                <a href="{{ route('users.show',['name'=>$user->name]) }}" class="text-dark">
+                    {{ $user->name }}
+                </a>
+            </h2>
+        </div>
+        <div class="card-body">
+            <div class="card-text">
+                <a href="" class="text-muted">
+                    10 フォロー
+                </a>
+                <a href="" class="text-muted">
+                    10 フォロワー
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -23,3 +23,6 @@ Route::prefix('projects')->name('projects.')->group(function() {
     Route::delete('/{project}/like','ProjectController@unlike')->name('unlike')->middleware('auth');
 });
 Route::get('/tags/{name}','TagController@show')->name('tags.show');
+Route::prefix('users')->name('users.')->group(function(){
+    Route::get('/{name}','UserController@show')->name('show');
+});


### PR DESCRIPTION
## 追加機能
- ユーザページの作成
- フォロー判定による、、フォローボタンの表示制御
    - 未フォローの場合は「フォロー」のボタン表示、
    - フォロー中の場合は「解除」のボタン表示
    - 現在はテーブルを直接更新する形でしか反映がされないため、追加対応が必要

## 残タスク
- アクションメソッドからフォローテーブルを更新し、結果をレスポンスさせる
- VueコンポーネントからLaravelへの非同期通信処理の実装
- フォロワー数、フォロイー数の表示
- フォロー中、フォロワーの一覧を表示する
- ユーザに紐づく記事の一覧をユーザページ上で表示させる
- ユーザがいいねした記事の一覧を表示する